### PR TITLE
Streams2

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -20,6 +20,7 @@
                                metosin/porsas {:mvn/version "0.0.1-alpha12"}
                                metosin/jsonista {:mvn/version "0.2.5"}
                                hikari-cp {:mvn/version "2.9.0"}
+                               ring {:mvn/version "1.7.1"}
                                com.clojure-goes-fast/clj-async-profiler {:mvn/version "0.4.0"}}
                   :jvm-opts ["-server"
                              "-Xms2G"

--- a/perf/pohjavirta/perf_test.clj
+++ b/perf/pohjavirta/perf_test.clj
@@ -1,6 +1,5 @@
 (ns pohjavirta.perf-test
   (:require [criterium.core :as cc]
-            [pohjavirta.server :as server]
             [pohjavirta.response :as response]
             [pohjavirta.ring :as ring]
             [pohjavirta.request :as request])

--- a/src/pohjavirta/response.clj
+++ b/src/pohjavirta/response.clj
@@ -106,10 +106,10 @@
   (send-body [stream ^HttpServerExchange exchange]
     (if (.isInIoThread exchange)
       (.dispatch exchange ^Runnable (fn []
-                                      (.startBlocking exchange)
                                       (send-body stream exchange)
                                       (.endExchange exchange)))
       (with-open [stream stream]
+        (.startBlocking exchange)
         (io/copy stream (.getOutputStream exchange)))))
 
   File

--- a/src/pohjavirta/response.clj
+++ b/src/pohjavirta/response.clj
@@ -113,10 +113,23 @@
         (io/copy stream (.getOutputStream exchange)))))
 
   File
-  (send-body [file exchange]
-    (.transferFrom (.getResponseSender ^HttpServerExchange exchange)
-                   (FileChannel/open (.toPath file) (into-array OpenOption []))
-                   IoCallback/END_EXCHANGE))
+  (send-body [file ^HttpServerExchange exchange]
+    (if (.isInIoThread exchange)
+      (.dispatch exchange ^Runnable (fn [] (send-body file exchange)))
+      (let [channel ^FileChannel (FileChannel/open (.toPath file) (into-array OpenOption []))
+            sender (.getResponseSender exchange)]
+        (.transferFrom
+          sender
+          channel
+          ^IoCallback
+          (reify
+            IoCallback
+            (onComplete [_ _ _]
+              (.close channel)
+              (.endExchange exchange))
+            (onException [_ _ _ exception]
+              (.close channel)
+              (.onException IoCallback/END_EXCHANGE exchange sender ^Exception exception)))))))
 
   Object
   (send-body [body _]

--- a/src/pohjavirta/response.clj
+++ b/src/pohjavirta/response.clj
@@ -114,22 +114,23 @@
 
   File
   (send-body [file ^HttpServerExchange exchange]
-    (if (.isInIoThread exchange)
-      (.dispatch exchange ^Runnable (fn [] (send-body file exchange)))
-      (let [channel ^FileChannel (FileChannel/open (.toPath file) (into-array OpenOption []))
-            sender (.getResponseSender exchange)]
-        (.transferFrom
-          sender
-          channel
-          ^IoCallback
-          (reify
-            IoCallback
-            (onComplete [_ _ _]
-              (.close channel)
-              (.endExchange exchange))
-            (onException [_ _ _ exception]
-              (.close channel)
-              (.onException IoCallback/END_EXCHANGE exchange sender ^Exception exception)))))))
+    (send-body (io/input-stream file) exchange)
+    #_(if (.isInIoThread exchange)
+        (.dispatch exchange ^Runnable (fn [] (send-body file exchange)))
+        (let [channel ^FileChannel (FileChannel/open (.toPath file) (into-array OpenOption []))
+              sender (.getResponseSender exchange)]
+          (.transferFrom
+            sender
+            channel
+            ^IoCallback
+            (reify
+              IoCallback
+              (onComplete [_ _ _]
+                (.close channel)
+                (.endExchange exchange))
+              (onException [_ _ _ exception]
+                (.close channel)
+                (.onException IoCallback/END_EXCHANGE exchange sender ^Exception exception)))))))
 
   Object
   (send-body [body _]

--- a/test/pohjavirta/server_test.clj
+++ b/test/pohjavirta/server_test.clj
@@ -4,7 +4,8 @@
             [pohjavirta.response :as response]
             [pohjavirta.exchange :as exchange]
             [pohjavirta.async :as a]
-            [hikari-cp.core :as hikari])
+            [hikari-cp.core :as hikari]
+            [ring.adapter.jetty :as jetty])
   (:import (java.nio ByteBuffer)
            (java.util.concurrent CompletableFuture)
            (io.undertow.server HttpHandler HttpServerExchange)
@@ -193,4 +194,6 @@
   (def server (server/create #'handler))
   (def server (server/create http-handler))
   (server/start server)
-  (server/stop server))
+  (server/stop server)
+
+  (jetty/run-jetty #'handler {:port 8088, :join? false}))


### PR DESCRIPTION
Fix file serving to close the file channels.  Use blocking IO as it seems to be faster than NIO here. WHY?

# with blocking IO

```
➜  pohjavirta git:(Streams2) ✗ wrk -t2 -c16 -d10s http://127.0.0.1:8080
Running 10s test @ http://127.0.0.1:8080
  2 threads and 16 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    11.54ms   24.19ms 132.47ms   87.01%
    Req/Sec     4.00k   609.08     5.47k    67.33%
  80445 requests in 10.10s, 14.67GB read
Requests/sec:   7963.88
Transfer/sec:      1.45GB
```

# with NIO

```
➜  pohjavirta git:(Streams2) ✗ wrk -t2 -c16 -d10s http://127.0.0.1:8080
Running 10s test @ http://127.0.0.1:8080
  2 threads and 16 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    23.04ms   32.01ms 104.22ms   79.49%
    Req/Sec     3.23k     1.00k    5.53k    66.50%
  64410 requests in 10.04s, 11.75GB read
Requests/sec:   6415.37
Transfer/sec:      1.17GB
```

# with Jetty

```
➜  pohjavirta git:(Streams2) ✗ wrk -t2 -c16 -d10s http://127.0.0.1:8088
Running 10s test @ http://127.0.0.1:8088
  2 threads and 16 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     5.14ms   14.98ms 144.37ms   94.50%
    Req/Sec     3.75k   424.51     6.01k    84.50%
  75127 requests in 10.05s, 13.69GB read
Requests/sec:   7473.10
Transfer/sec:      1.36GB
```