### PR TITLE
Websocket support

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,8 @@
 {:paths ["src" "resources" "target"]
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {lambdaisland/kaocha {:mvn/version "0.0-573"}
-                               org.clojure/clojure {:mvn/version "1.10.1"}}}
+                               org.clojure/clojure {:mvn/version "1.10.1"}
+                               stylefruits/gniazdo {:mvn/version "1.1.3"}}}
            :jar {:extra-deps {pack/pack.alpha
                               {:git/url "https://github.com/juxt/pack.alpha.git"
                                :sha "60cdf0e75efc988b893eafe726ccdf0d5a5a6067"}}

--- a/src/pohjavirta/Util.java
+++ b/src/pohjavirta/Util.java
@@ -6,6 +6,7 @@ import java.nio.ByteBuffer;
 
 public class Util {
 
+    // From org.projectodd.wunderboss.web.undertow.async.websocket.UndertowWebsocket
     public static byte[] toArray(ByteBuffer... payload) {
         if (payload.length == 1) {
             ByteBuffer buf = payload[0];

--- a/src/pohjavirta/Util.java
+++ b/src/pohjavirta/Util.java
@@ -1,0 +1,23 @@
+package pohjavirta;
+
+import org.xnio.Buffers;
+
+import java.nio.ByteBuffer;
+
+public class Util {
+
+    public static byte[] toArray(ByteBuffer... payload) {
+        if (payload.length == 1) {
+            ByteBuffer buf = payload[0];
+            if (buf.hasArray() && buf.arrayOffset() == 0 && buf.position() == 0) {
+                return buf.array();
+            }
+        }
+        int size = (int) Buffers.remaining(payload);
+        byte[] data = new byte[size];
+        for (ByteBuffer buf : payload) {
+            buf.get(data);
+        }
+        return data;
+    }
+}

--- a/src/pohjavirta/websocket.clj
+++ b/src/pohjavirta/websocket.clj
@@ -1,39 +1,51 @@
 (ns pohjavirta.websocket
   (:import [io.undertow.websockets WebSocketConnectionCallback]
-           [io.undertow.websockets.core WebSocketChannel
-                                        AbstractReceiveListener
-                                        BufferedTextMessage]
+           [io.undertow.websockets.core AbstractReceiveListener
+                                        BufferedBinaryMessage
+                                        BufferedTextMessage
+                                        CloseMessage
+                                        WebSocketChannel]
            [io.undertow.websockets.spi WebSocketHttpExchange]
            [io.undertow Handlers]
-           [org.xnio ChannelListener]))
+           [org.xnio ChannelListener]
+           [pohjavirta Util]))
 
 ;; this may fit better elsewhere. At first start here though to keep modular
 
 (defn ws-listener
   "Default listener"
-  [{:keys [on-receive on-close on-error]
-    :or   {on-receive (constantly nil)
+  [{:keys [on-message on-close on-error]
+    :or   {on-message (constantly nil)
            on-close   (constantly nil)
            on-error   (constantly nil)}}]
   (proxy [AbstractReceiveListener] []
     (onFullTextMessage [^WebSocketChannel channel ^BufferedTextMessage message]
-      (on-receive {:channel channel
+      (on-message {:channel channel
                    :data    (.getData message)}))
-    (onClose [^WebSocketChannel ws-channel _]
-      (on-close {:channel ws-channel}))
+    (onFullBinaryMessage [^WebSocketChannel channel ^BufferedBinaryMessage message]
+      (let [pooled (.getData message)]
+        (try
+          (let [payload (.getResource pooled)]
+            (on-message {:channel channel
+                         :data (Util/toArray payload)}))
+          (finally
+            (.free pooled)))))
+    (onCloseMessage [^CloseMessage message ^WebSocketChannel channel]
+      (on-close {:channel channel
+                 :message message}))
     (onError [^WebSocketChannel channel ^Throwable error]
       (on-error {:channel channel
                  :error   error}))))
 
 (defn ws-callback
-  [{:keys [on-connect listener] :as ws-opts}]
+  [{:keys [on-open listener] :as ws-opts}]
   (let [listener (if (instance? ChannelListener listener)
                    listener
                    (ws-listener ws-opts))]
     (reify WebSocketConnectionCallback
       (^void onConnect [_ ^WebSocketHttpExchange exchange ^WebSocketChannel channel]
+        (on-open {:channel channel})
         (.set (.getReceiveSetter channel) listener)
-        (on-connect {:channel channel})
         (.resumeReceives channel)))))
 
 (defn ws-handler

--- a/src/pohjavirta/websocket.clj
+++ b/src/pohjavirta/websocket.clj
@@ -4,31 +4,37 @@
                                         AbstractReceiveListener
                                         BufferedTextMessage]
            [io.undertow.websockets.spi WebSocketHttpExchange]
-           [io.undertow Handlers]))
+           [io.undertow Handlers]
+           [org.xnio ChannelListener]))
 
 ;; this may fit better elsewhere. At first start here though to keep modular
 
-(defn ws-listener [{:keys [on-receive on-close on-error]}]
+(defn ws-listener
+  "Default listener"
+  [{:keys [on-receive on-close on-error]
+    :or   {on-receive (constantly nil)
+           on-close   (constantly nil)
+           on-error   (constantly nil)}}]
   (proxy [AbstractReceiveListener] []
     (onFullTextMessage [^WebSocketChannel channel ^BufferedTextMessage message]
-      (when on-receive
-        (on-receive {:channel channel
-                     :data (.getData message)})))
+      (on-receive {:channel channel
+                   :data    (.getData message)}))
     (onClose [^WebSocketChannel ws-channel _]
-      (when on-close
-        (on-close {:channel ws-channel})))
+      (on-close {:channel ws-channel}))
     (onError [^WebSocketChannel channel ^Throwable error]
-      (when on-error
-        (on-error {:channel channel
-                   :error   error})))))
+      (on-error {:channel channel
+                 :error   error}))))
 
 (defn ws-callback
-  [{:keys [on-connect] :as ws-opts}]
-  (reify WebSocketConnectionCallback
-    (^void onConnect [_ ^WebSocketHttpExchange exchange ^WebSocketChannel channel]
-      (.set (.getReceiveSetter channel) (ws-listener ws-opts))
-      (on-connect {:channel channel})
-      (.resumeReceives channel))))
+  [{:keys [on-connect listener] :as ws-opts}]
+  (let [listener (if (instance? ChannelListener listener)
+                   listener
+                   (ws-listener ws-opts))]
+    (reify WebSocketConnectionCallback
+      (^void onConnect [_ ^WebSocketHttpExchange exchange ^WebSocketChannel channel]
+        (.set (.getReceiveSetter channel) listener)
+        (on-connect {:channel channel})
+        (.resumeReceives channel)))))
 
 (defn ws-handler
   "Convenience function to create a basic websocket handler"

--- a/src/pohjavirta/websocket.clj
+++ b/src/pohjavirta/websocket.clj
@@ -1,12 +1,10 @@
 (ns pohjavirta.websocket
-  (:import [io.undertow.websockets WebSocketConnectionCallback
-                                   WebSocketProtocolHandshakeHandler]
+  (:import [io.undertow.websockets WebSocketConnectionCallback]
            [io.undertow.websockets.core WebSocketChannel
                                         AbstractReceiveListener
                                         BufferedTextMessage]
-           [io.undertow.server HttpHandler
-                               HttpServerExchange]
-           [io.undertow.websockets.spi WebSocketHttpExchange]))
+           [io.undertow.websockets.spi WebSocketHttpExchange]
+           [io.undertow Handlers]))
 
 ;; this may fit better elsewhere. At first start here though to keep modular
 
@@ -35,7 +33,4 @@
 (defn ws-handler
   "Convenience function to create a basic websocket handler"
   [opts]
-  (let [ws-handshake-handler (WebSocketProtocolHandshakeHandler. ^WebSocketConnectionCallback (ws-callback opts))]
-    (reify HttpHandler
-      (^void handleRequest [_ ^HttpServerExchange exchange]
-        (.handleRequest ws-handshake-handler exchange)))))
+  (Handlers/websocket (ws-callback opts)))

--- a/src/pohjavirta/websocket.clj
+++ b/src/pohjavirta/websocket.clj
@@ -13,7 +13,14 @@
 ;; this may fit better elsewhere. At first start here though to keep modular
 
 (defn ws-listener
-  "Default listener"
+  "Default websocket listener
+
+   Takes a map of functions as opts:
+   :on-message | fn taking map of keys :channel, :data
+   :on-close   | fn taking map of keys :channel, :message
+   :on-error   | fn taking map of keys :channel, :error
+
+   Each key defaults to no action"
   [{:keys [on-message on-close on-error]
     :or   {on-message (constantly nil)
            on-close   (constantly nil)

--- a/src/pohjavirta/websocket.clj
+++ b/src/pohjavirta/websocket.clj
@@ -45,7 +45,9 @@
                  :error   error}))))
 
 (defn ws-callback
-  [{:keys [on-open listener] :as ws-opts}]
+  [{:keys [on-open listener]
+    :or   {on-open (constantly nil)}
+    :as   ws-opts}]
   (let [listener (if (instance? ChannelListener listener)
                    listener
                    (ws-listener ws-opts))]

--- a/src/pohjavirta/websocket.clj
+++ b/src/pohjavirta/websocket.clj
@@ -1,0 +1,41 @@
+(ns pohjavirta.websocket
+  (:import [io.undertow.websockets WebSocketConnectionCallback
+                                   WebSocketProtocolHandshakeHandler]
+           [io.undertow.websockets.core WebSocketChannel
+                                        AbstractReceiveListener
+                                        BufferedTextMessage]
+           [io.undertow.server HttpHandler
+                               HttpServerExchange]
+           [io.undertow.websockets.spi WebSocketHttpExchange]))
+
+;; this may fit better elsewhere. At first start here though to keep modular
+
+(defn ws-listener [{:keys [on-receive on-close on-error]}]
+  (proxy [AbstractReceiveListener] []
+    (onFullTextMessage [^WebSocketChannel channel ^BufferedTextMessage message]
+      (when on-receive
+        (on-receive {:channel channel
+                     :data (.getData message)})))
+    (onClose [^WebSocketChannel ws-channel _]
+      (when on-close
+        (on-close {:channel ws-channel})))
+    (onError [^WebSocketChannel channel ^Throwable error]
+      (when on-error
+        (on-error {:channel channel
+                   :error   error})))))
+
+(defn ws-callback
+  [{:keys [on-connect] :as ws-opts}]
+  (reify WebSocketConnectionCallback
+    (^void onConnect [_ ^WebSocketHttpExchange exchange ^WebSocketChannel channel]
+      (.set (.getReceiveSetter channel) (ws-listener ws-opts))
+      (on-connect {:channel channel})
+      (.resumeReceives channel))))
+
+(defn ws-handler
+  "Convenience function to create a basic websocket handler"
+  [opts]
+  (let [ws-handshake-handler (WebSocketProtocolHandshakeHandler. ^WebSocketConnectionCallback (ws-callback opts))]
+    (reify HttpHandler
+      (^void handleRequest [_ ^HttpServerExchange exchange]
+        (.handleRequest ws-handshake-handler exchange)))))

--- a/test/pohjavirta/websocket_test.clj
+++ b/test/pohjavirta/websocket_test.clj
@@ -1,0 +1,33 @@
+(ns pohjavirta.websocket-test
+  (:require [clojure.test :refer :all]
+            [pohjavirta.websocket :as ws]
+            [gniazdo.core :as gniazdo]
+            [pohjavirta.server :as server]))
+
+(set! *warn-on-reflection* true)
+
+(defn test-websocket
+  []
+  (let [events  (atom [])
+        errors  (atom [])
+        result  (promise)
+        config  {:on-connect (fn [_]
+                               (swap! events conj :open))
+                 :on-receive (fn [{:keys [data]}]
+                               (swap! events conj data))
+                 :on-close   (fn [_]
+                               (deliver result @events))
+                 :on-error   (fn [{:keys [error]}]
+                               (swap! errors conj error))}
+        handler (ws/ws-handler config)
+        server  (server/create handler)]
+    (try
+      (server/start server)
+      (let [socket (gniazdo/connect "ws://localhost:8080/")]
+        (gniazdo/send-msg socket "hello")
+        (gniazdo/close socket))
+      (deref result 2000 :fail)
+      (finally
+        (server/stop server)))))
+
+(test-websocket)

--- a/test/pohjavirta/websocket_test.clj
+++ b/test/pohjavirta/websocket_test.clj
@@ -11,9 +11,9 @@
   (let [events  (atom [])
         errors  (atom [])
         result  (promise)
-        config  {:on-connect (fn [_]
+        config  {:on-open    (fn [_]
                                (swap! events conj :open))
-                 :on-receive (fn [{:keys [data]}]
+                 :on-message (fn [{:keys [data]}]
                                (swap! events conj data))
                  :on-close   (fn [_]
                                (deliver result (swap! events conj :close)))

--- a/test/pohjavirta/websocket_test.clj
+++ b/test/pohjavirta/websocket_test.clj
@@ -16,7 +16,7 @@
                  :on-receive (fn [{:keys [data]}]
                                (swap! events conj data))
                  :on-close   (fn [_]
-                               (deliver result @events))
+                               (deliver result (swap! events conj :close)))
                  :on-error   (fn [{:keys [error]}]
                                (swap! errors conj error))}
         handler (ws/ws-handler config)
@@ -30,4 +30,5 @@
       (finally
         (server/stop server)))))
 
-(test-websocket)
+(comment
+  (test-websocket))


### PR DESCRIPTION
Goals with this feature addition. If any are misaligned with the lib, please push back.

1) Allow user to override any of the implementations, e.g. custom listener or callback
2) Attempt to keep API similar (though not identical) to immutant -- should allow for relatively easy plugability with libs like sente
3) Make modular, i.e. so that it can be moved as needed and not directly tied into pohjavirta. The rationale is that many web applications do not require this so it should be an opt-in functionality with custom user-written code to hook it together (perhaps should add helpers?)

Open to feedback and discussion before merging.

Re https://github.com/metosin/pohjavirta/issues/1